### PR TITLE
Version 1.1.0 release

### DIFF
--- a/Guard.Tests/GuardComparableTests.cs
+++ b/Guard.Tests/GuardComparableTests.cs
@@ -2,8 +2,12 @@ using Fitomad.Guard;
 
 namespace Guard.Tests;
 
-public class GuardNumberTests
+public class GuardComparableTests
 {
+    private DateTime Today => DateTime.Now;
+    private DateTime Tomorrow => DateTime.Now.AddDays(1);
+    private DateTime Yesterday => DateTime.Now.AddDays(-1);
+
     [Theory]
     [InlineData(5, 0, 10)]
     [InlineData(0, -5, 5)]
@@ -86,9 +90,9 @@ public class GuardNumberTests
     [Theory]
     [InlineData(1, 0)]
     [InlineData(0, -1)]
-    public void Test_GreaterInteger(int value, int otherNumber)
+    public void Test_Greater(IComparable value, IComparable otherNumber)
     {
-        Fitomad.Guard.Guard.NumberIsGreater(number: value, upperBound: otherNumber);
+        Fitomad.Guard.Guard.IsGreater(value, upperBound: otherNumber);
     }
 
     [Theory]
@@ -96,7 +100,7 @@ public class GuardNumberTests
     [InlineData(0.0, -0.1)]
     public void Test_GreaterDouble(double value, double otherNumber)
     {
-        Fitomad.Guard.Guard.NumberIsGreater(number: value, upperBound: otherNumber);
+        Fitomad.Guard.Guard.IsGreater(value, upperBound: otherNumber);
     }
 
     [Theory]
@@ -105,7 +109,7 @@ public class GuardNumberTests
     public void Test_GreaterIntegerThrowing(int value, int otherNumber)
     {
         Assert.Throws<ArgumentException>(testCode: () => {
-            Fitomad.Guard.Guard.NumberIsGreater(number: value, upperBound: otherNumber);
+            Fitomad.Guard.Guard.IsGreater(value, upperBound: otherNumber);
         });
     }
 
@@ -115,7 +119,7 @@ public class GuardNumberTests
     public void Test_GreaterDoubleThrowing(double value, double otherNumber)
     {
         Assert.Throws<ArgumentException>(testCode: () => {
-            Fitomad.Guard.Guard.NumberIsGreater(number: value, upperBound: otherNumber);
+            Fitomad.Guard.Guard.IsGreater(value, upperBound: otherNumber);
         });
     }
 
@@ -125,7 +129,7 @@ public class GuardNumberTests
     [InlineData(-1, 0)]
     public void Test_LowerInteger(int value, int otherNumber)
     {
-        Fitomad.Guard.Guard.NumberIsLower(number: value, lowerBound: otherNumber);
+        Fitomad.Guard.Guard.IsLower(value, lowerBound: otherNumber);
     }
 
     [Theory]
@@ -133,7 +137,7 @@ public class GuardNumberTests
     [InlineData(-0.1, 0.0)]
     public void Test_LowerDouble(double value, double otherNumber)
     {
-        Fitomad.Guard.Guard.NumberIsLower(number: value, lowerBound: otherNumber);
+        Fitomad.Guard.Guard.IsLower(value, lowerBound: otherNumber);
     }
 
     [Theory]
@@ -142,7 +146,7 @@ public class GuardNumberTests
     public void Test_LowerIntegerThrowing(int value, int otherNumber)
     {
         Assert.Throws<ArgumentException>(testCode: () => {
-            Fitomad.Guard.Guard.NumberIsLower(number: value, lowerBound: otherNumber);
+            Fitomad.Guard.Guard.IsLower(value, lowerBound: otherNumber);
         });
     }
 
@@ -152,7 +156,88 @@ public class GuardNumberTests
     public void Test_LowerDoubleThrowing(double value, double otherNumber)
     {
         Assert.Throws<ArgumentException>(testCode: () => {
-            Fitomad.Guard.Guard.NumberIsLower(number: value, lowerBound: otherNumber);
+            Fitomad.Guard.Guard.IsLower(value: value, lowerBound: otherNumber);
+        });
+    }
+
+    [Fact]
+    public void Test_DateInRange()
+    {
+        Fitomad.Guard.Guard.InRange(Today, lowerBound: Yesterday, upperBound:Tomorrow);
+    }
+
+    [Fact]
+    public void Test_DateInRangeThrowing()
+    {
+        Assert.Throws<IndexOutOfRangeException>(testCode: () => 
+        {
+            Fitomad.Guard.Guard.InRange(Yesterday, lowerBound: Today, upperBound:Tomorrow); 
+        });
+    }
+
+    [Fact]
+    public void Test_DateInRangeThrowingCustom()
+    {
+        Assert.Throws<GuardTestException>(testCode: () => 
+        {
+            Fitomad.Guard.Guard.InRange(Yesterday, lowerBound: Today, upperBound:Tomorrow, perform: () =>
+            {
+                throw new GuardTestException();
+            }); 
+        });
+    }
+
+    [Fact]
+    public void Test_DateLower()
+    {
+        Fitomad.Guard.Guard.IsLower(Yesterday, lowerBound: Today);
+    }
+
+    [Fact]
+    public void Test_DateLowerThrowing()
+    {
+        Assert.Throws<ArgumentException>(testCode: () => 
+        {
+            Fitomad.Guard.Guard.IsLower(Today, lowerBound: Yesterday); 
+        });
+    }
+
+    [Fact]
+    public void Test_DateLowerThrowingCustom()
+    {
+        Assert.Throws<GuardTestException>(testCode: () => 
+        {
+            Fitomad.Guard.Guard.IsLower(Today, lowerBound: Yesterday, perform: () =>
+            {
+                throw new GuardTestException();
+            }); 
+        });
+    }
+
+    [Fact]
+    public void Test_DateGreater()
+    {
+        Fitomad.Guard.Guard.IsGreater(Tomorrow, upperBound: Today);
+    }
+
+    [Fact]
+    public void Test_DateGreaterThrowing()
+    {
+        Assert.Throws<ArgumentException>(testCode: () => 
+        {
+            Fitomad.Guard.Guard.IsGreater(Today, upperBound: Tomorrow); 
+        });
+    }
+
+    [Fact]
+    public void Test_DateGreaterThrowingCustom()
+    {
+        Assert.Throws<GuardTestException>(testCode: () => 
+        {
+            Fitomad.Guard.Guard.IsGreater(Today, upperBound: Tomorrow, perform: () =>
+            {
+                throw new GuardTestException();
+            }); 
         });
     }
 }

--- a/Guard.Tests/GuardStringTests.cs
+++ b/Guard.Tests/GuardStringTests.cs
@@ -78,8 +78,81 @@ public class GuardStringTests
         Assert.Throws<ArgumentException>(testCode: () => 
         {
             Fitomad.Guard.Guard.Length(content, stringLength: (expectedLength + 1));
-        });
-        
+        });   
     }
 
+    [Theory]
+    [InlineData("fitomad", "itoma")]
+    [InlineData("Spain", "Spain")]
+    [InlineData("Madrid", "d")]
+    [InlineData("Madrid", "M")]
+    [InlineData("Spain", "pai")]
+    public void Test_StringContains(string content, string substring)
+    {
+        Fitomad.Guard.Guard.Contains(content, substring: substring);
+    }
+
+    [Theory]
+    [InlineData("Microsoft", "Apple")]
+    [InlineData("Spain", "USA")]
+    [InlineData("Madrid", "Seattle")]
+    [InlineData("Madrid", "New York")]
+    [InlineData("Spain", "count")]
+    public void Test_StringContainsThrowing(string content, string substring)
+    {
+        Assert.Throws<ArgumentException>(testCode: () => 
+        {
+            Fitomad.Guard.Guard.Contains(content, substring: substring);
+        }); 
+    }
+
+    [Theory]
+    [InlineData("fitomad", "fito")]
+    [InlineData("Spain", "Spa")]
+    [InlineData("Madrid", "M")]
+    [InlineData("Madrid", "Madri")]
+    [InlineData("Spain", "Spain")]
+    public void Test_StartsWith(string content, string testString)
+    {
+        Fitomad.Guard.Guard.StartsWith(content, prefix: testString);
+    }
+
+    [Theory]
+    [InlineData("Microsoft", "micro")]
+    [InlineData("Spain", "U")]
+    [InlineData("Madrid", "Seattl")]
+    [InlineData("Madrid", "New ")]
+    [InlineData("Spain", " ")]
+    public void Test_StartsWithThrowing(string content, string substring)
+    {
+        Assert.Throws<ArgumentException>(testCode: () => 
+        {
+            Fitomad.Guard.Guard.Contains(content, substring: substring);
+        }); 
+    }
+
+    [Theory]
+    [InlineData("fitomad", "mad")]
+    [InlineData("Spain", "in")]
+    [InlineData("Madrid", "d")]
+    [InlineData("Madrid", "adrid")]
+    [InlineData("USA", "SA")]
+    public void Test_EndsWith(string content, string testString)
+    {
+        Fitomad.Guard.Guard.EndsWith(content, suffix: testString);
+    }
+
+    [Theory]
+    [InlineData("Microsoft", "pple")]
+    [InlineData("Spain", "SA")]
+    [InlineData("Madrid", "eattle")]
+    [InlineData("Madrid", " York")]
+    [InlineData("Spain", "spain")]
+    public void Test_EndsWithThrowing(string content, string testString)
+    {
+        Assert.Throws<ArgumentException>(testCode: () => 
+        {
+            Fitomad.Guard.Guard.EndsWith(content, suffix: testString);
+        }); 
+    }
 }

--- a/Guard.Tests/GuardTests.cs
+++ b/Guard.Tests/GuardTests.cs
@@ -24,7 +24,7 @@ public class GuardTests
     [InlineData("Is Not Null")]
     public void Test_NotNull(object parameter)
     {
-        Fitomad.Guard.Guard.IsNotNull(parameter);
+        Fitomad.Guard.Guard.NotNull(parameter);
     }
 
     [Theory]
@@ -32,7 +32,7 @@ public class GuardTests
     public void Test_NotNullThrowing(object parameter)
     {
         Assert.Throws<ArgumentException>(testCode: () => {
-            Fitomad.Guard.Guard.IsNotNull(parameter);
+            Fitomad.Guard.Guard.NotNull(parameter);
         });
     }
 
@@ -44,7 +44,7 @@ public class GuardTests
     [InlineData(100, 1009)]
     public void Test_NonEqualIntegers(int lhs, int rhs)
     {
-        Fitomad.Guard.Guard.NonEquals(lhs, rhs);
+        Fitomad.Guard.Guard.NotEquals(lhs, rhs);
     }
 
 
@@ -57,7 +57,7 @@ public class GuardTests
     public void Test_NonEqualIntegersThrowing(int lhs, int rhs)
     {
         Assert.Throws<ArgumentException>(testCode: () => {
-            Fitomad.Guard.Guard.NonEquals(lhs, rhs);
+            Fitomad.Guard.Guard.NotEquals(lhs, rhs);
         });
     }
 
@@ -69,7 +69,7 @@ public class GuardTests
     [InlineData("", "")]
     public void Test_EqualString(string lhs, string rhs)
     {
-        Fitomad.Guard.Guard.Equals(lhs, rhs);
+        Fitomad.Guard.Guard.IsEquals(lhs, rhs);
     }
 
     [Theory]
@@ -81,7 +81,7 @@ public class GuardTests
     public void Test_EqualStringThrowing(string lhs, string rhs)
     {
         Assert.Throws<ArgumentException>(testCode: () => {
-            Fitomad.Guard.Guard.Equals(lhs, rhs);
+            Fitomad.Guard.Guard.IsEquals(lhs, rhs);
         });
     }
 
@@ -90,7 +90,7 @@ public class GuardTests
     public void Test_NonEqualNonThrowingAction(string lhs, string rhs)
     {
         Assert.Throws<ArgumentException>(testCode: () => {
-            Fitomad.Guard.Guard.NonEquals(lhs, rhs, perform: () => {
+            Fitomad.Guard.Guard.NotEquals(lhs, rhs, perform: () => {
                 // We do some work here...
             });
         });
@@ -101,7 +101,7 @@ public class GuardTests
     public void Test_NonEqualThrowingActionCustomException(string lhs, string rhs)
     {
         Assert.Throws<GuardTestException>(testCode: () => {
-            Fitomad.Guard.Guard.NonEquals(lhs, rhs, perform: () => {
+            Fitomad.Guard.Guard.NotEquals(lhs, rhs, perform: () => {
                 // We do some work here...
                 throw new GuardTestException();
             });

--- a/Guard/Guard.Boolean.cs
+++ b/Guard/Guard.Boolean.cs
@@ -1,9 +1,14 @@
+using Fitomad.Guard.Resources;
+
 namespace Fitomad.Guard;
 
 public sealed partial class Guard
 {
     public static void IsTrue(bool element) {
-        Guard.IsTrue(element, perform: ArgumentAction);
+        GuardResourceManager resourceManager = new();
+        Action isTrueAction = Guard.MakeArgumentAction(resourceManager.IsTrueMessage);
+
+        Guard.IsTrue(element, perform: isTrueAction);
     }
 
     public static void IsTrue(bool element, Action perform) {
@@ -14,7 +19,10 @@ public sealed partial class Guard
     }
 
     public static void IsFalse(bool element) {
-        Guard.IsFalse(element, perform: ArgumentAction);
+        GuardResourceManager resourceManager = new();
+        Action isFalseAction = Guard.MakeArgumentAction(resourceManager.IsFalseMessage);
+
+        Guard.IsFalse(element, perform: isFalseAction);
     }
 
     public static void IsFalse(bool element, Action perform) {

--- a/Guard/Guard.Boolean.cs
+++ b/Guard/Guard.Boolean.cs
@@ -14,10 +14,7 @@ public sealed partial class Guard
     }
 
     public static void IsFalse(bool element) {
-        Guard.IsFalse(element, perform: () =>
-        {
-            throw new ArgumentException();
-        });
+        Guard.IsFalse(element, perform: ArgumentAction);
     }
 
     public static void IsFalse(bool element, Action perform) {

--- a/Guard/Guard.Collections.cs
+++ b/Guard/Guard.Collections.cs
@@ -1,3 +1,5 @@
+using Fitomad.Guard.Resources;
+
 namespace Fitomad.Guard;
 
 public sealed partial class Guard
@@ -39,6 +41,11 @@ public sealed partial class Guard
         {
             Execute(perform);
         }
+    }
+
+    public static void NotEmpty<Element>(ICollection<Element> collection)
+    {
+        Guard.NotEmpty(collection, perform: ArgumentAction);
     }
 
     public static void NotEmpty<Element>(ICollection<Element> collection, Action perform)

--- a/Guard/Guard.Collections.cs
+++ b/Guard/Guard.Collections.cs
@@ -2,6 +2,11 @@ namespace Fitomad.Guard;
 
 public sealed partial class Guard
 {
+    public static void Contains<Element>(Element element, ICollection<Element> collection)
+    {
+        Guard.Contains(element, collection: collection, perform: ArgumentAction);
+    }
+
     public static void Contains<Element>(Element element, ICollection<Element> collection, Action perform)
     {
         if(!collection.Contains(element))
@@ -10,12 +15,22 @@ public sealed partial class Guard
         }
     }
 
-    public static void DoesNotContains<Element>(Element element, ICollection<Element> collection, Action perform)
+    public static void NotContains<Element>(Element element, ICollection<Element> collection)
+    {
+        Guard.NotContains(element, collection: collection, perform: ArgumentAction);
+    }
+
+    public static void NotContains<Element>(Element element, ICollection<Element> collection, Action perform)
     {
         if(collection.Contains(element))
         {
             Execute(perform);
         }
+    }
+
+    public static void IsEmpty<Element>(ICollection<Element> collection)
+    {
+        Guard.IsEmpty(collection, perform: ArgumentAction);
     }
 
     public static void IsEmpty<Element>(ICollection<Element> collection, Action perform)

--- a/Guard/Guard.Equatable.cs
+++ b/Guard/Guard.Equatable.cs
@@ -1,10 +1,15 @@
+using Fitomad.Guard.Resources;
+
 namespace Fitomad.Guard;
 
 public sealed partial class Guard
 {
     public static void IsNull(object element)
     {
-        Guard.IsNull(element, perform: ArgumentAction);
+        GuardResourceManager resourceManager = new();
+        Action isNullAction = MakeArgumentAction(errorMessage: resourceManager.IsNull);
+
+        Guard.IsNull(element, perform: isNullAction);
     }
 
     public static void IsNull(object element, Action perform)
@@ -15,23 +20,31 @@ public sealed partial class Guard
         }
     }
 
-    public static void IsNotNull(object element) {
-        Guard.IsNotNull(element, perform: ArgumentAction);
+    public static void NotNull(object element) 
+    {
+        GuardResourceManager resourceManager = new();
+        Action notNullAction = MakeArgumentAction(errorMessage: resourceManager.NotNull);
+
+        Guard.NotNull(element, perform: notNullAction);
     }
 
-    public static void IsNotNull(object element, Action perform) {
+    public static void NotNull(object element, Action perform) {
         if (element is null) 
         {
             Execute(perform);
         }
     }
 
-    public static void Equals<Element>(Element lhs, Element rhs) where Element : IEquatable<Element>
+    public static void IsEquals<Element>(Element lhs, Element rhs) where Element : IEquatable<Element>
     {
-        Guard.Equals(lhs, rhs, perform: ArgumentAction);
+        GuardResourceManager resourceManager = new();
+        var isEqualsMessage = string.Format(resourceManager.IsEquals, lhs, rhs);
+        Action isEqualsAction = MakeArgumentAction(errorMessage: isEqualsMessage);
+        
+        Guard.IsEquals(lhs, rhs, perform: isEqualsAction);
     }
 
-    public static void Equals<Element>(Element lhs, Element rhs, Action perform) where Element : IEquatable<Element>
+    public static void IsEquals<Element>(Element lhs, Element rhs, Action perform) where Element : IEquatable<Element>
     {
         if(!lhs.Equals(rhs))
         {
@@ -39,12 +52,16 @@ public sealed partial class Guard
         }
     }
 
-    public static void NonEquals<Element>(Element lhs, Element rhs) where Element : IEquatable<Element>
+    public static void NotEquals<Element>(Element lhs, Element rhs) where Element : IEquatable<Element>
     {
-        Guard.NonEquals(lhs, rhs, perform: ArgumentAction);
+        GuardResourceManager resourceManager = new();
+        var notEqualsMessage = string.Format(resourceManager.NotEquals, lhs, rhs);
+        Action notEqualsAction = MakeArgumentAction(errorMessage: notEqualsMessage);
+        
+        Guard.NotEquals(lhs, rhs, perform: notEqualsAction);
     }
 
-    public static void NonEquals<Element>(Element lhs, Element rhs, Action perform) where Element : IEquatable<Element>
+    public static void NotEquals<Element>(Element lhs, Element rhs, Action perform) where Element : IEquatable<Element>
     {
         if(lhs.Equals(rhs))
         {

--- a/Guard/Guard.Numbers.cs
+++ b/Guard/Guard.Numbers.cs
@@ -2,8 +2,6 @@ using Fitomad.Guard.Resources;
 
 namespace Fitomad.Guard;
 
-using ComparableBound = (int lowerBound, int upperBound);
-
 public sealed partial class Guard
 {
     public static void InRange<Element>(Element value, Element lowerBound, Element upperBound) where Element : IComparable

--- a/Guard/Guard.Numbers.cs
+++ b/Guard/Guard.Numbers.cs
@@ -1,5 +1,7 @@
 namespace Fitomad.Guard;
 
+using ComparableBound = (int lowerBound, int upperBound);
+
 public sealed partial class Guard
 {
     public static void InRange<Element>(Element value, Element lowerBound, Element upperBound) where Element : IComparable
@@ -18,53 +20,61 @@ public sealed partial class Guard
         }
     }
 
-    public static void NumberIsLower(double number, double lowerBound) 
+    public static void IsLower<Element>(Element value, Element lowerBound)  where Element : IComparable
     {
-        Guard.NumberIsLower(number, lowerBound: lowerBound, perform: ArgumentAction);   
+        Guard.IsLower(value, lowerBound: lowerBound, perform: ArgumentAction);   
     }
 
-    public static void NumberIsLower(double number, double lowerBound, Action perform) 
+    public static void IsLower<Element>(Element value, Element lowerBound, Action perform)  where Element : IComparable
     {
-        if (number >= lowerBound)
+        bool rangeStartCheck = value.CompareTo(lowerBound) >= 0;
+
+        if (rangeStartCheck)
         {
             Execute(perform);
         }
     }
 
-    public static void NumberIsLowerOrEquals(double number, double lowerBound) 
+    public static void IsLowerOrEquals<Element>(Element value, Element lowerBound)  where Element : IComparable
     {
-        Guard.NumberIsLowerOrEquals(number, lowerBound: lowerBound, perform: ArgumentAction);   
+        Guard.IsLowerOrEquals(value, lowerBound: lowerBound, perform: ArgumentAction);   
     }
 
-    public static void NumberIsLowerOrEquals(double number, double lowerBound, Action perform) 
+    public static void IsLowerOrEquals<Element>(Element value, Element lowerBound, Action perform)  where Element : IComparable
     {
-        if (number > lowerBound)
+        bool rangeStartCheck = value.CompareTo(lowerBound) >= 0;
+
+        if (rangeStartCheck)
         {
             Execute(perform);
         }
     }
 
-    public static void NumberIsGreater(double number, double upperBound) 
+    public static void IsGreater<Element>(Element value, Element upperBound)  where Element : IComparable
     {
-        Guard.NumberIsGreater(number, upperBound: upperBound, perform: ArgumentAction);
+        Guard.IsGreater(value, upperBound: upperBound, perform: ArgumentAction);
     }
 
-    public static void NumberIsGreater(double number, double upperBound, Action perform) 
+    public static void IsGreater<Element>(Element value, Element upperBound, Action perform)  where Element : IComparable
     {
-        if (number <= upperBound)
+        bool rangeEndCheck = value.CompareTo(upperBound) <= 0;
+
+        if (rangeEndCheck)
         {
             Execute(perform);
         }
     }
 
-    public static void NumberIsGreaterOrEquals(double number, double upperBound) 
+    public static void IsGreaterOrEquals<Element>(Element value, Element upperBound)  where Element : IComparable
     {
-        Guard.NumberIsGreaterOrEquals(number, upperBound: upperBound, perform: ArgumentAction);
+        Guard.IsGreaterOrEquals(value, upperBound: upperBound, perform: ArgumentAction);
     }
 
-    public static void NumberIsGreaterOrEquals(double number, double upperBound, Action perform) 
+    public static void IsGreaterOrEquals<Element>(Element value, Element upperBound, Action perform)  where Element : IComparable
     {
-        if (number < upperBound)
+        bool rangeEndCheck = value.CompareTo(upperBound) < 0;
+
+        if (rangeEndCheck)
         {
             Execute(perform);
         }

--- a/Guard/Guard.Numbers.cs
+++ b/Guard/Guard.Numbers.cs
@@ -28,7 +28,11 @@ public sealed partial class Guard
 
     public static void IsLower<Element>(Element value, Element lowerBound)  where Element : IComparable
     {
-        Guard.IsLower(value, lowerBound: lowerBound, perform: ArgumentAction);   
+        GuardResourceManager resourceManager = new();
+        var isLowerMessage = string.Format(resourceManager.IsLower, value, lowerBound);
+        Action isLowerAction = MakeArgumentAction(errorMessage: isLowerMessage);
+
+        Guard.IsLower(value, lowerBound: lowerBound, perform: isLowerAction);   
     }
 
     public static void IsLower<Element>(Element value, Element lowerBound, Action perform)  where Element : IComparable
@@ -43,7 +47,11 @@ public sealed partial class Guard
 
     public static void IsLowerOrEquals<Element>(Element value, Element lowerBound)  where Element : IComparable
     {
-        Guard.IsLowerOrEquals(value, lowerBound: lowerBound, perform: ArgumentAction);   
+        GuardResourceManager resourceManager = new();
+        var IsLowerOrEqualsMessage = string.Format(resourceManager.IsLowerOrEquals, value, lowerBound);
+        Action IsLowerOrEqualsAction = MakeArgumentAction(errorMessage: IsLowerOrEqualsMessage);
+
+        Guard.IsLowerOrEquals(value, lowerBound: lowerBound, perform: IsLowerOrEqualsAction);   
     }
 
     public static void IsLowerOrEquals<Element>(Element value, Element lowerBound, Action perform)  where Element : IComparable
@@ -58,7 +66,11 @@ public sealed partial class Guard
 
     public static void IsGreater<Element>(Element value, Element upperBound)  where Element : IComparable
     {
-        Guard.IsGreater(value, upperBound: upperBound, perform: ArgumentAction);
+        GuardResourceManager resourceManager = new();
+        var isGreaterMessage = string.Format(resourceManager.IsGreater, value, upperBound);
+        Action isGreaterAction = MakeArgumentAction(errorMessage: isGreaterMessage);
+
+        Guard.IsGreater(value, upperBound: upperBound, perform: isGreaterAction);
     }
 
     public static void IsGreater<Element>(Element value, Element upperBound, Action perform)  where Element : IComparable
@@ -73,7 +85,11 @@ public sealed partial class Guard
 
     public static void IsGreaterOrEquals<Element>(Element value, Element upperBound)  where Element : IComparable
     {
-        Guard.IsGreaterOrEquals(value, upperBound: upperBound, perform: ArgumentAction);
+        GuardResourceManager resourceManager = new();
+        var isGreaterOrEqualsMessage = string.Format(resourceManager.IsGreaterOrEquals, value, upperBound);
+        Action isGreaterOrEqualsAction = MakeArgumentAction(errorMessage: isGreaterOrEqualsMessage);
+
+        Guard.IsGreaterOrEquals(value, upperBound: upperBound, perform: isGreaterOrEqualsAction);
     }
 
     public static void IsGreaterOrEquals<Element>(Element value, Element upperBound, Action perform)  where Element : IComparable

--- a/Guard/Guard.Numbers.cs
+++ b/Guard/Guard.Numbers.cs
@@ -1,3 +1,5 @@
+using Fitomad.Guard.Resources;
+
 namespace Fitomad.Guard;
 
 using ComparableBound = (int lowerBound, int upperBound);
@@ -6,6 +8,10 @@ public sealed partial class Guard
 {
     public static void InRange<Element>(Element value, Element lowerBound, Element upperBound) where Element : IComparable
     {
+        GuardResourceManager resourceManager = new();
+        var inRangeMessage = string.Format(resourceManager.InRangeMessage, value, lowerBound, upperBound);
+        Action inRangeAction = MakeArgumentAction(errorMessage: inRangeMessage);
+
         Guard.InRange(value, lowerBound: lowerBound, upperBound: upperBound, perform: RangeAction);
     }
 

--- a/Guard/Guard.Regex.cs
+++ b/Guard/Guard.Regex.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Fitomad.Guard.Resources;
 
 namespace Fitomad.Guard;
 
@@ -6,7 +7,11 @@ public sealed partial class Guard
 {
     public static void Match(string content, string regularExpression)
     {
-        Match(content, regularExpression: regularExpression, perform: ArgumentAction);
+        GuardResourceManager resourceManager = new();
+        var matchMessage = string.Format(resourceManager.Match, content, regularExpression);
+        Action matchAction = MakeArgumentAction(errorMessage: matchMessage);
+
+        Match(content, regularExpression: regularExpression, perform: matchAction);
     }
 
     public static void Match(string content, string regularExpression, Action perform)
@@ -21,7 +26,11 @@ public sealed partial class Guard
 
     public static void NotMatch(string content, string regularExpression)
     {
-        NotMatch(content, regularExpression: regularExpression, perform: ArgumentAction);
+        GuardResourceManager resourceManager = new();
+        var notMatchMessage = string.Format(resourceManager.NotMatch, content, regularExpression);
+        Action notMatchAction = MakeArgumentAction(errorMessage: notMatchMessage);
+
+        NotMatch(content, regularExpression: regularExpression, perform: notMatchAction);
     }
 
     public static void NotMatch(string content, string regularExpression, Action perform)

--- a/Guard/Guard.String.cs
+++ b/Guard/Guard.String.cs
@@ -40,4 +40,82 @@ public sealed partial class Guard
             Execute(perform);
         }
     }
+
+    public static void Contains(string content, string substring)
+    {
+        Guard.Contains(content, substring: substring, perform: ArgumentAction);
+    }
+
+    public static void Contains(string content, string substring, Action perform)
+    {
+        if (!content.Contains(substring))
+        {
+            Execute(perform);
+        }
+    }
+
+    public static void NotContains(string content, string substring)
+    {
+        Guard.NotContains(content, substring: substring, perform: ArgumentAction);
+    }
+
+    public static void NotContains(string content, string substring, Action perform)
+    {
+        if (content.Contains(substring))
+        {
+            Execute(perform);
+        }
+    }
+
+    public static void StarsWith(string content, string prefix)
+    {
+        Guard.StartsWith(content, prefix: prefix, perform: ArgumentAction);
+    }
+
+    public static void StartsWith(string content, string prefix, Action perform)
+    {
+        if (!content.StartsWith(prefix))
+        {
+            Execute(perform);
+        }
+    }
+
+    public static void NotStartsWith(string content, string prefix)
+    {
+        Guard.NotStartsWith(content, prefix: prefix, perform: ArgumentAction);
+    }
+
+    public static void NotStartsWith(string content, string prefix, Action perform)
+    {
+        if (content.StartsWith(prefix))
+        {
+            Execute(perform);
+        }
+    }
+
+    public static void EndsWith(string content, string prefix)
+    {
+        Guard.EndsWith(content, prefix: prefix, perform: ArgumentAction);
+    }
+
+    public static void EndsWith(string content, string prefix, Action perform)
+    {
+        if (!content.EndsWith(prefix))
+        {
+            Execute(perform);
+        }
+    }
+
+    public static void NotEndsWith(string content, string prefix)
+    {
+        Guard.NotEndsWith(content, prefix: prefix, perform: ArgumentAction);
+    }
+
+    public static void NotEndsWith(string content, string prefix, Action perform)
+    {
+        if (content.EndsWith(prefix))
+        {
+            Execute(perform);
+        }
+    }
 }

--- a/Guard/Guard.String.cs
+++ b/Guard/Guard.String.cs
@@ -1,10 +1,16 @@
+using Fitomad.Guard.Resources;
+
 namespace Fitomad.Guard;
 
 public sealed partial class Guard 
 {
     public static void IsEmpty(string content)
     {
-        Guard.IsEmpty(content, perform: ArgumentAction);
+        GuardResourceManager resourceManager = new();
+        var isEmptyStringMessage = string.Format(resourceManager.IsEmptyString, content);
+        Action isEmptyStringAction = MakeArgumentAction(errorMessage: isEmptyStringMessage);
+
+        Guard.IsEmpty(content, perform: isEmptyStringAction);
     }
 
     public static void IsEmpty(string content, Action perform)
@@ -17,7 +23,10 @@ public sealed partial class Guard
 
     public static void NotEmpty(string content)
     {
-        Guard.NotEmpty(content, perform: ArgumentAction);
+        GuardResourceManager resourceManager = new();
+        Action notEmptyStringAction = MakeArgumentAction(errorMessage: resourceManager.NotEmptyString);
+
+        Guard.NotEmpty(content, perform: notEmptyStringAction);
     }
 
     public static void NotEmpty(string content, Action perform)
@@ -30,7 +39,11 @@ public sealed partial class Guard
 
     public static void Length(string content, int stringLength)
     {
-        Guard.Length(content, stringLength: stringLength, perform: ArgumentAction);
+        GuardResourceManager resourceManager = new();
+        var lengthMessage = string.Format(resourceManager.Length, content, stringLength);
+        Action lengthAction = MakeArgumentAction(errorMessage: lengthMessage);
+
+        Guard.Length(content, stringLength: stringLength, perform: lengthAction);
     }
 
     public static void Length(string content, int stringLength, Action perform)
@@ -43,7 +56,11 @@ public sealed partial class Guard
 
     public static void Contains(string content, string substring)
     {
-        Guard.Contains(content, substring: substring, perform: ArgumentAction);
+        GuardResourceManager resourceManager = new();
+        var containsMessage = string.Format(resourceManager.ContainsString, content, substring);
+        Action containsAction = MakeArgumentAction(errorMessage: containsMessage);
+
+        Guard.Contains(content, substring: substring, perform: containsAction);
     }
 
     public static void Contains(string content, string substring, Action perform)
@@ -56,6 +73,10 @@ public sealed partial class Guard
 
     public static void NotContains(string content, string substring)
     {
+        GuardResourceManager resourceManager = new();
+        var notContainsMessage = string.Format(resourceManager.NotContainsString, content, substring);
+        Action notContainsAction = MakeArgumentAction(errorMessage: notContainsMessage);
+
         Guard.NotContains(content, substring: substring, perform: ArgumentAction);
     }
 
@@ -67,9 +88,13 @@ public sealed partial class Guard
         }
     }
 
-    public static void StarsWith(string content, string prefix)
+    public static void StartsWith(string content, string prefix)
     {
-        Guard.StartsWith(content, prefix: prefix, perform: ArgumentAction);
+        GuardResourceManager resourceManager = new();
+        var startsWithMessage = string.Format(resourceManager.StartsWith, content, prefix);
+        Action startsWithAction = MakeArgumentAction(errorMessage: startsWithMessage);
+
+        Guard.StartsWith(content, prefix: prefix, perform: startsWithAction);
     }
 
     public static void StartsWith(string content, string prefix, Action perform)
@@ -82,7 +107,11 @@ public sealed partial class Guard
 
     public static void NotStartsWith(string content, string prefix)
     {
-        Guard.NotStartsWith(content, prefix: prefix, perform: ArgumentAction);
+        GuardResourceManager resourceManager = new();
+        var notStartsWithMessage = string.Format(resourceManager.NotStartsWith, content, prefix);
+        Action notStartsWithAction = MakeArgumentAction(errorMessage: notStartsWithMessage);
+
+        Guard.NotStartsWith(content, prefix: prefix, perform: notStartsWithAction);
     }
 
     public static void NotStartsWith(string content, string prefix, Action perform)
@@ -93,27 +122,35 @@ public sealed partial class Guard
         }
     }
 
-    public static void EndsWith(string content, string prefix)
+    public static void EndsWith(string content, string suffix)
     {
-        Guard.EndsWith(content, prefix: prefix, perform: ArgumentAction);
+        GuardResourceManager resourceManager = new();
+        var endsWithMessage = string.Format(resourceManager.EndsWith, content, suffix);
+        Action endsWithAction = MakeArgumentAction(errorMessage: endsWithMessage);
+
+        Guard.EndsWith(content, suffix: suffix, perform: endsWithAction);
     }
 
-    public static void EndsWith(string content, string prefix, Action perform)
+    public static void EndsWith(string content, string suffix, Action perform)
     {
-        if (!content.EndsWith(prefix))
+        if (!content.EndsWith(suffix))
         {
             Execute(perform);
         }
     }
 
-    public static void NotEndsWith(string content, string prefix)
+    public static void NotEndsWith(string content, string suffix)
     {
-        Guard.NotEndsWith(content, prefix: prefix, perform: ArgumentAction);
+        GuardResourceManager resourceManager = new();
+        var notEndsMessage = string.Format(resourceManager.NotEndsWith, content, suffix);
+        Action notEndsAction = MakeArgumentAction(errorMessage: notEndsMessage);
+
+        Guard.NotEndsWith(content, suffix: suffix, perform: notEndsAction);
     }
 
-    public static void NotEndsWith(string content, string prefix, Action perform)
+    public static void NotEndsWith(string content, string suffix, Action perform)
     {
-        if (content.EndsWith(prefix))
+        if (content.EndsWith(suffix))
         {
             Execute(perform);
         }

--- a/Guard/Guard.cs
+++ b/Guard/Guard.cs
@@ -22,4 +22,14 @@ public sealed partial class Guard
             throw;
         }
     }
+
+    private static Action MakeArgumentAction(string errorMessage)
+    {
+        Console.WriteLine(errorMessage);
+        Action action = () => {
+            throw new ArgumentException(errorMessage);
+        };
+
+        return action;
+    }
 }

--- a/Guard/Guard.csproj
+++ b/Guard/Guard.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <!-- nuget -->
     <PackageId>Fitomad.Guard</PackageId>
-    <Version>1.0.2</Version>
+    <Version>1.1.0</Version>
     <Authors>Adolfo</Authors>
     <Company>Fitomad</Company>
     <Description>Fitomad.Guard is a .NET library implements the Guard clause approach.</Description>

--- a/Guard/Guard.csproj
+++ b/Guard/Guard.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AssemblyName>Fitomad.Guard</AssemblyName>
     <!-- nuget -->
     <PackageId>Fitomad.Guard</PackageId>
     <Version>1.1.0</Version>

--- a/Guard/Resources/Messages.resx
+++ b/Guard/Resources/Messages.resx
@@ -7,6 +7,32 @@
   <data name="IsFalse" xml:space="preserve">  
     <value>Expected value is not false</value>  
   </data>
+  <!-- Collections -->
+  <data name="Contains" xml:space="preserve">  
+    <value>Collection not contains {0}</value>  
+  </data>
+  <data name="NotContains" xml:space="preserve">  
+    <value>{0} is in the collection</value>  
+  </data>
+  <data name="IsEmpty" xml:space="preserve">  
+    <value>Collection is not empty</value>  
+  </data>
+  <data name="NotEmpty" xml:space="preserve">  
+    <value>Collection is empty</value>  
+  </data>
+  <!-- Equatables -->
+  <data name="IsNull" xml:space="preserve">  
+    <value>Element is not nul</value>  
+  </data>
+  <data name="NotNull" xml:space="preserve">  
+    <value>Element is null</value>  
+  </data>
+  <data name="IsEquals" xml:space="preserve">  
+    <value>{0} is not equals to {1}</value>  
+  </data>
+  <data name="NotEquals" xml:space="preserve">  
+    <value>{0} is equals to {1}</value>  
+  </data>
   <!-- Comparables -->
   <data name="InRange" xml:space="preserve">  
     <value>{0} is not included in range {1}...{2}</value>  
@@ -22,5 +48,40 @@
   </data> 
   <data name="IsGreaterOrEquals" xml:space="preserve">  
     <value>{0} is not greater or equal than {1}</value>  
+  </data>
+  <!-- Regular Expressions -->
+  <data name="Match" xml:space="preserve">  
+    <value>{0} does not match the regular expression: {1}</value>  
+  </data>
+  <data name="NotMatch" xml:space="preserve">  
+    <value>{0} match the regular expression: {1}</value>  
+  </data>
+  <!-- Strings -->
+  <data name="IsEmptyString" xml:space="preserve">  
+    <value>String {0} is not empty</value>  
+  </data>
+  <data name="NotEmptyString" xml:space="preserve">  
+    <value>String is empty</value>  
+  </data>
+  <data name="Length" xml:space="preserve">  
+    <value>The string {0} has a different length than the expected ({1})</value>  
+  </data>
+  <data name="ContainsString" xml:space="preserve">  
+    <value>The string {0} does not contains the substring {1}</value>  
+  </data>
+  <data name="NotContainsString" xml:space="preserve">  
+    <value>The string {0} contains the substring {1}</value>  
+  </data>
+  <data name="StartsWith" xml:space="preserve">  
+    <value>The string {0} does not starts with prefix {1}</value>  
+  </data>
+  <data name="NotStartsWith" xml:space="preserve">  
+    <value>The string {0} starts with prefix {1}</value>  
+  </data>
+  <data name="EndsWith" xml:space="preserve">  
+    <value>The string {0} does not ends with suffix {1}</value>  
+  </data>
+  <data name="NotEndsWith" xml:space="preserve">  
+    <value>The string {0} ends with suffix {1}</value>  
   </data>
 </root>  

--- a/Guard/Resources/Messages.resx
+++ b/Guard/Resources/Messages.resx
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>  
+<root>  
+  <!-- Boolean -->
+  <data name="IsTrue" xml:space="preserve">  
+    <value>Expected value is not true</value>  
+  </data>  
+  <data name="IsFalse" xml:space="preserve">  
+    <value>Expected value is not false</value>  
+  </data>
+  <!-- Comparables -->
+  <data name="InRange" xml:space="preserve">  
+    <value>{0} is not included in range {1}...{2}</value>  
+  </data>  
+  <data name="IsLower" xml:space="preserve">  
+    <value>{0} is not lower than {1}</value>  
+  </data> 
+  <data name="IsLowerOrEquals" xml:space="preserve">  
+    <value>{0} is not lower or equal than {1}</value>  
+  </data>
+  <data name="IsGreater" xml:space="preserve">  
+    <value>{0} is not greater than {1}</value>  
+  </data> 
+  <data name="IsGreaterOrEquals" xml:space="preserve">  
+    <value>{0} is not greater or equal than {1}</value>  
+  </data>
+</root>  

--- a/Guard/Resources/ResourceManager.cs
+++ b/Guard/Resources/ResourceManager.cs
@@ -1,0 +1,26 @@
+using System.Globalization;
+using System.Resources;
+
+namespace Fitomad.Guard.Resources;
+
+sealed class GuardResourceManager
+{
+    private ResourceManager _resourceManager;
+    private CultureInfo _currentCulture;
+
+    internal string IsTrueMessage => _resourceManager.GetString("IsTrue", _currentCulture) ?? "";
+    internal string IsFalseMessage => _resourceManager.GetString("IsFalse", _currentCulture) ?? "";
+    
+    internal string InRangeMessage => _resourceManager.GetString("InRange", _currentCulture) ?? "";
+    internal string IsLower => _resourceManager.GetString("IsLower", _currentCulture) ?? "";
+    internal string IsLowerOrEquals => _resourceManager.GetString("IsLowerOrEquals", _currentCulture) ?? "";
+    internal string IsGreater => _resourceManager.GetString("IsGreater", _currentCulture) ?? "";
+    internal string IsGreaterOrEquals => _resourceManager.GetString("IsGreaterOrEquals", _currentCulture) ?? "";
+
+
+    internal GuardResourceManager()
+    {
+        _currentCulture = CultureInfo.CurrentCulture;  
+        _resourceManager = new ResourceManager("Guard.Resources.Messages", typeof(GuardResourceManager).Assembly);
+    }
+}

--- a/Guard/Resources/ResourceManager.cs
+++ b/Guard/Resources/ResourceManager.cs
@@ -11,12 +11,34 @@ sealed class GuardResourceManager
     internal string IsTrueMessage => _resourceManager.GetString("IsTrue", _currentCulture) ?? "";
     internal string IsFalseMessage => _resourceManager.GetString("IsFalse", _currentCulture) ?? "";
     
+    internal string ContainsMessage => _resourceManager.GetString("Contains", _currentCulture) ?? "";
+    internal string NotContainsMessage => _resourceManager.GetString("NotContains", _currentCulture) ?? "";
+    internal string IsEmptyCollectionMessage => _resourceManager.GetString("IsEmpty", _currentCulture) ?? "";
+    internal string NotEmptyCollectionMessage => _resourceManager.GetString("NotEmpty", _currentCulture) ?? "";
+    
+    internal string IsNull => _resourceManager.GetString("IsNull", _currentCulture) ?? "";
+    internal string NotNull => _resourceManager.GetString("NotNull", _currentCulture) ?? "";
+    internal string IsEquals => _resourceManager.GetString("IsEquals", _currentCulture) ?? "";
+    internal string NotEquals => _resourceManager.GetString("NotEquals", _currentCulture) ?? "";
+
     internal string InRangeMessage => _resourceManager.GetString("InRange", _currentCulture) ?? "";
     internal string IsLower => _resourceManager.GetString("IsLower", _currentCulture) ?? "";
     internal string IsLowerOrEquals => _resourceManager.GetString("IsLowerOrEquals", _currentCulture) ?? "";
     internal string IsGreater => _resourceManager.GetString("IsGreater", _currentCulture) ?? "";
     internal string IsGreaterOrEquals => _resourceManager.GetString("IsGreaterOrEquals", _currentCulture) ?? "";
 
+    internal string Match => _resourceManager.GetString("Match", _currentCulture) ?? "";
+    internal string NotMatch => _resourceManager.GetString("NotMatch", _currentCulture) ?? "";
+
+    internal string IsEmptyString => _resourceManager.GetString("IsEmptyString", _currentCulture) ?? "";
+    internal string NotEmptyString => _resourceManager.GetString("NotEmptyString", _currentCulture) ?? "";
+    internal string Length => _resourceManager.GetString("Length", _currentCulture) ?? "";
+    internal string ContainsString => _resourceManager.GetString("ContainsString", _currentCulture) ?? "";
+    internal string NotContainsString => _resourceManager.GetString("NotContainsString", _currentCulture) ?? "";
+    internal string StartsWith => _resourceManager.GetString("StartsWith", _currentCulture) ?? "";
+    internal string NotStartsWith => _resourceManager.GetString("NotStartsWith", _currentCulture) ?? "";
+    internal string EndsWith => _resourceManager.GetString("EndsWith", _currentCulture) ?? "";
+    internal string NotEndsWith => _resourceManager.GetString("NotEndsWith", _currentCulture) ?? "";
 
     internal GuardResourceManager()
     {


### PR DESCRIPTION
## Strings

There are new operations available:

- StarsWith
- NotStartsWith
- EndsWith
- NotEndsWith

## Collections

Some methods have been renamed

- DoesNotContains renamed to NotContains
- Added default code for all operations

## Comparable

Now all types that implements the `IComparable` interface can be used in the following operations

- InRage
- IsGreater
- IsGreaterOrEquals
- IsLower
- IsLowerOrEquals

## Equatable

Some methods have been renamed

- IsNotNull renamed to NotNul
- Equals renamed to IsEquals
- NonEquals renames to NotEquals

## Other

Some methods have been renamed to bring better readability experience

- NumberIsLower renamed to IsLower
- NumberIsLowerOrEquals renamed to IsLowerOrEquals
- NumberIsGreater renamed to IsGreater
- NumberIsGreaterOrEquals renamed to IsGreaterOrEquals 

## Errors

Now, default exceptions provide a friendly developer message for each error. 

This PR close #2 issue